### PR TITLE
Support promise cancellation (cancellation of underlying DNS lookup)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "evenement/evenement": "~1.0|~2.0",
         "react/event-loop": ">=0.2, <0.5",
         "react/dns": ">=0.2, <0.5",
-        "react/promise": "~2.0|~1.1"
+        "react/promise": "~2.1|~1.2"
     },
     "require-dev": {
         "clue/block-react": "~1.0"

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -119,4 +119,28 @@ class FactoryTest extends TestCase
     {
         Block\await($this->factory->createServer('/////'), $this->loop);
     }
+
+    public function testCancelCreateClientWithCancellableHostnameResolver()
+    {
+        $promise = new Promise\Promise(function () { }, $this->expectCallableOnce());
+        $this->resolver->expects($this->once())->method('resolve')->with('example.com')->willReturn($promise);
+
+        $promise = $this->factory->createClient('example.com:0');
+        $promise->cancel();
+
+        $this->setExpectedException('RuntimeException');
+        Block\await($promise, $this->loop);
+    }
+
+    public function testCancelCreateClientWithUncancellableHostnameResolver()
+    {
+        $promise = $this->getMock('React\Promise\PromiseInterface');
+        $this->resolver->expects($this->once())->method('resolve')->with('example.com')->willReturn($promise);
+
+        $promise = $this->factory->createClient('example.com:0');
+        $promise->cancel();
+
+        $this->setExpectedException('RuntimeException');
+        Block\await($promise, $this->loop);
+    }
 }


### PR DESCRIPTION
~~This PR builds on top of #11, so the diff also includes its changes. Will rebase this once #11 is in.~~ (no longer applies after rebasing)

Closes #10