### PR TITLE
Properly format IPv6 addresses and return null for unknown addresses

### DIFF
--- a/src/Socket.php
+++ b/src/Socket.php
@@ -36,16 +36,12 @@ class Socket extends EventEmitter implements SocketInterface
 
     public function getLocalAddress()
     {
-        if ($this->socket !== false) {
-            return $this->sanitizeAddress(stream_socket_get_name($this->socket, false));
-        }
+        return $this->sanitizeAddress(@stream_socket_get_name($this->socket, false));
     }
 
     public function getRemoteAddress()
     {
-        if ($this->socket !== false) {
-            return $this->sanitizeAddress(stream_socket_get_name($this->socket, true));
-        }
+        return $this->sanitizeAddress(@stream_socket_get_name($this->socket, true));
     }
 
     public function send($data, $remoteAddress = null)

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -37,14 +37,14 @@ class Socket extends EventEmitter implements SocketInterface
     public function getLocalAddress()
     {
         if ($this->socket !== false) {
-            return stream_socket_get_name($this->socket, false);
+            return $this->sanitizeAddress(stream_socket_get_name($this->socket, false));
         }
     }
 
     public function getRemoteAddress()
     {
         if ($this->socket !== false) {
-            return stream_socket_get_name($this->socket, true);
+            return $this->sanitizeAddress(stream_socket_get_name($this->socket, true));
         }
     }
 
@@ -102,16 +102,15 @@ class Socket extends EventEmitter implements SocketInterface
 
     private function sanitizeAddress($address)
     {
-        // doc comment suggests IPv6 address is not enclosed in square brackets?
+        if ($address === false) {
+            return null;
+        }
 
-        $pos = strrpos($address, ':');
         // this is an IPv6 address which includes colons but no square brackets
-        if ($pos !== false && substr($address, 0, 1) !== '[') {
-            if (strpos($address, ':') < $pos) {
-                $port = substr($address, $pos + 1);
-                $address = '[' . substr($address, 0, $pos) . ']:' . $port;
-            }
-
+        $pos = strrpos($address, ':');
+        if ($pos !== false && strpos($address, ':') < $pos && substr($address, 0, 1) !== '[') {
+            $port = substr($address, $pos + 1);
+            $address = '[' . substr($address, 0, $pos) . ']:' . $port;
         }
         return $address;
     }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -25,7 +25,14 @@ class FactoryTest extends TestCase
         $capturedClient = Block\await($promise, $this->loop);
         $this->assertInstanceOf('React\Datagram\Socket', $capturedClient);
 
+        $this->assertEquals('127.0.0.1:12345', $capturedClient->getRemoteAddress());
+
+        $this->assertContains('127.0.0.1:', $capturedClient->getLocalAddress());
+        $this->assertNotEquals('127.0.0.1:12345', $capturedClient->getLocalAddress());
+
         $capturedClient->close();
+
+        $this->assertNull($capturedClient->getRemoteAddress());
     }
 
     public function testCreateClientLocalhost()
@@ -34,6 +41,11 @@ class FactoryTest extends TestCase
 
         $capturedClient = Block\await($promise, $this->loop);
         $this->assertInstanceOf('React\Datagram\Socket', $capturedClient);
+
+        $this->assertEquals('127.0.0.1:12345', $capturedClient->getRemoteAddress());
+
+        $this->assertContains('127.0.0.1:', $capturedClient->getLocalAddress());
+        $this->assertNotEquals('127.0.0.1:12345', $capturedClient->getLocalAddress());
 
         $capturedClient->close();
     }
@@ -45,6 +57,11 @@ class FactoryTest extends TestCase
         $capturedClient = Block\await($promise, $this->loop);
         $this->assertInstanceOf('React\Datagram\Socket', $capturedClient);
 
+        $this->assertEquals('[::1]:12345', $capturedClient->getRemoteAddress());
+
+        $this->assertContains('[::1]:', $capturedClient->getLocalAddress());
+        $this->assertNotEquals('[::1]:12345', $capturedClient->getLocalAddress());
+
         $capturedClient->close();
     }
 
@@ -55,7 +72,12 @@ class FactoryTest extends TestCase
         $capturedServer = Block\await($promise, $this->loop);
         $this->assertInstanceOf('React\Datagram\Socket', $capturedServer);
 
+        $this->assertEquals('127.0.0.1:12345', $capturedServer->getLocalAddress());
+        $this->assertNull($capturedServer->getRemoteAddress());
+
         $capturedServer->close();
+
+        $this->assertNull($capturedServer->getLocalAddress());
     }
 
     public function testCreateServerRandomPort()
@@ -66,6 +88,7 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf('React\Datagram\Socket', $capturedServer);
 
         $this->assertNotEquals('127.0.0.1:0', $capturedServer->getLocalAddress());
+        $this->assertNull($capturedServer->getRemoteAddress());
 
         $capturedServer->close();
     }


### PR DESCRIPTION
UDP6/IPv6 addresses should be returned as `[::1]:12345` instead of the non-standard, ambiguous `::1:12345`.

Refs reactphp/react#199