### PR TITLE
Target evenement 3.0 a long side 2.0 and 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "php": ">=5.3",
-        "evenement/evenement": "~1.0|~2.0",
+        "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
         "react/event-loop": ">=0.2, <0.5",
         "react/dns": ">=0.2, <0.5",
         "react/promise": "~2.1|~1.2"


### PR DESCRIPTION
Événement `3.0` is nearly fully backwards compatible with `2.0` and `1.0` and `react/datagram` is fully compatible with all three so why not support it. It packs some neat performance upgrades without any code changes on `react/datagram`'s side :shipit: .