### PR TITLE
Update Travis build config so new defaults do not break the build 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ php:
   - 5.6
   - 7
 
+# lock distro so new future defaults will not break the build
+dist: precise
+
 # also test against HHVM, but require "trusty" and ignore errors
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,20 @@
 language: php
 
 php:
-  - 5.3
+# - 5.3 # requires old distro, see below
   - 5.4
   - 5.5
   - 5.6
   - 7
+  - hhvm # ignore errors, see below
 
 # lock distro so new future defaults will not break the build
-dist: precise
+dist: trusty
 
-# also test against HHVM, but require "trusty" and ignore errors
 matrix:
   include:
-    - php: hhvm
-      dist: trusty
+    - php: 5.3
+      dist: precise
   allow_failures:
     - php: hhvm
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,14 @@ php:
   - 5.5
   - 5.6
   - 7
-  - hhvm
+
+# also test against HHVM, but require "trusty" and ignore errors
+matrix:
+  include:
+    - php: hhvm
+      dist: trusty
+  allow_failures:
+    - php: hhvm
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ php:
 sudo: false
 
 install:
-  - composer install --prefer-source --no-interaction
+  - composer install --no-interaction
 
 script:
-  - phpunit --coverage-text
+  - vendor/bin/phpunit --coverage-text

--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ $ composer require react/datagram:^1.1.1
 
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
+## Tests
+
+To run the test suite, you first need to clone this repo and then install all
+dependencies [through Composer](http://getcomposer.org):
+
+```bash
+$ composer install
+```
+
+To run the test suite, go to the project root and run:
+
+```bash
+$ php vendor/bin/phpunit
+```
+
 ## License
 
 MIT

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "react/promise": "~2.1|~1.2"
     },
     "require-dev": {
-        "clue/block-react": "~1.0"
+        "clue/block-react": "~1.0",
+        "phpunit/phpunit": "^4.8"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,6 @@
     },
     "require-dev": {
         "clue/block-react": "~1.0",
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^5.0 || ^4.8"
     }
 }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -162,7 +162,7 @@ class FactoryTest extends TestCase
 
     public function testCancelCreateClientWithUncancellableHostnameResolver()
     {
-        $promise = $this->getMock('React\Promise\PromiseInterface');
+        $promise = $this->getMockBuilder('React\Promise\PromiseInterface')->getMock();
         $this->resolver->expects($this->once())->method('resolve')->with('example.com')->willReturn($promise);
 
         $promise = $this->factory->createClient('example.com:0');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -26,7 +26,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
 
     protected function createCallableMock()
     {
-        return $this->getMock('CallableStub');
+        return $this->getMockBuilder('CallableStub')->getMock();
     }
 
     protected function createResolverMock()


### PR DESCRIPTION
Travis is in the process of upgrading the base distro (https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming) and has started marking all existing PRs as broken.

While updating the default distro, they also removed support for some older versions of PHP (travis-ci/travis-ci#7163). These versions are still supported by this project, so we now have to explicitly define the base distro to test against.

Originally from https://github.com/clue/php-http-proxy-react/pull/12 and clue/php-connection-manager-extra#24