### PR TITLE
Update DNS dependency to support hosts file on all platforms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     "require": {
         "php": ">=5.3",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
-        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3 || ^0.2",
-        "react/dns": ">=0.2, <0.5",
+        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
+        "react/dns": "^0.4.11",
         "react/promise": "~2.1|~1.2"
     },
     "require-dev": {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -98,10 +98,6 @@ class Factory
         if (false !== filter_var($host, FILTER_VALIDATE_IP)) {
             return Promise\resolve($host);
         }
-        // todo: remove this once the dns resolver can handle the hosts file!
-        if ($host === 'localhost') {
-            return Promise\resolve('127.0.0.1');
-        }
 
         if ($this->resolver === null) {
             return Promise\reject(new Exception('No resolver given in order to get IP address for given hostname'));

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -20,6 +20,8 @@ class FactoryTest extends TestCase
 
     public function testCreateClient()
     {
+        $this->resolver->expects($this->never())->method('resolve');
+
         $promise = $this->factory->createClient('127.0.0.1:12345');
 
         $capturedClient = Block\await($promise, $this->loop);
@@ -37,6 +39,8 @@ class FactoryTest extends TestCase
 
     public function testCreateClientLocalhost()
     {
+        $this->resolver->expects($this->once())->method('resolve')->with('localhost')->willReturn(Promise\resolve('127.0.0.1'));
+
         $promise = $this->factory->createClient('localhost:12345');
 
         $capturedClient = Block\await($promise, $this->loop);


### PR DESCRIPTION
The default `Resolver` now honors the hosts file on all platforms by default. This means that you can now connect to `localhost` etc..

Refs https://github.com/reactphp/dns/pull/75 and https://github.com/reactphp/socket/pull/112