### PR TITLE
Update DNS dependency and load system default DNS config on all supported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Once [installed](#install), you can use the following code to connect to an UDP 
 
 ```php
 $loop = React\EventLoop\Factory::create();
-
 $factory = new React\Datagram\Factory($loop);
 
 $factory->createClient('localhost:1234')->then(function (React\Datagram\Socket $client) {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.3",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
-        "react/dns": "^0.4.11",
+        "react/dns": "^0.4.13",
         "react/promise": "~2.1|~1.2"
     },
     "require-dev": {

--- a/examples/client.php
+++ b/examples/client.php
@@ -3,11 +3,7 @@
 require_once __DIR__.'/../vendor/autoload.php';
 
 $loop = React\EventLoop\Factory::create();
-
-$factory = new React\Dns\Resolver\Factory();
-$resolver = $factory->createCached('8.8.8.8', $loop);
-
-$factory = new React\Datagram\Factory($loop, $resolver);
+$factory = new React\Datagram\Factory($loop);
 
 $factory->createClient('localhost:1234')->then(function (React\Datagram\Socket $client) use ($loop) {
     $client->send('first');

--- a/examples/server.php
+++ b/examples/server.php
@@ -3,7 +3,6 @@
 require_once __DIR__.'/../vendor/autoload.php';
 
 $loop = React\EventLoop\Factory::create();
-
 $factory = new React\Datagram\Factory($loop);
 
 $factory->createServer('localhost:1234')->then(function (React\Datagram\Socket $server) {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -3,6 +3,7 @@
 namespace React\Datagram;
 
 use React\Datagram\Socket;
+use React\Dns\Config\Config;
 use React\Dns\Resolver\Factory as DnsFactory;
 use React\Dns\Resolver\Resolver;
 use React\EventLoop\LoopInterface;
@@ -19,13 +20,18 @@ class Factory
      *
      * @param LoopInterface $loop
      * @param Resolver|null $resolver Resolver instance to use. Will otherwise
-     *     default to using Google's public DNS 8.8.8.8
+     *     try to load the system default DNS config or fall back to using
+     *     Google's public DNS 8.8.8.8
      */
     public function __construct(LoopInterface $loop, Resolver $resolver = null)
     {
         if ($resolver === null) {
+            // try to load nameservers from system config or default to Google's public DNS
+            $config = Config::loadSystemConfigBlocking();
+            $server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
+
             $factory = new DnsFactory();
-            $resolver = $factory->create('8.8.8.8', $loop);
+            $resolver = $factory->create($server, $loop);
         }
 
         $this->loop = $loop;


### PR DESCRIPTION
This simple PR updates the DNS dependency to take advantage of the new config loader to apply the system default DNS config on all supported platforms. The previous default DNS server `8.8.8.8` will only be used as a fallback if no other DNS server could be found.

Resolves / closes #21
Refs https://github.com/reactphp/dns/pull/93
Refs https://github.com/reactphp/socket/pull/152