### PR TITLE
Slightly more clear peer address resolvement

### DIFF
--- a/src/Socket.php
+++ b/src/Socket.php
@@ -64,7 +64,7 @@ class Socket extends EventEmitter implements SocketInterface
     public function onReceive()
     {
         try {
-            $data = $this->handleReceive($peer);
+            list($data, $peer) = $this->handleReceive();
         }
         catch (Exception $e) {
             // emit error message and local socket
@@ -111,7 +111,7 @@ class Socket extends EventEmitter implements SocketInterface
         return $address;
     }
 
-    protected function handleReceive(&$peerAddress)
+    protected function handleReceive()
     {
         $data = stream_socket_recvfrom($this->socket, $this->bufferSize, 0, $peerAddress);
 
@@ -125,7 +125,7 @@ class Socket extends EventEmitter implements SocketInterface
 
         $peerAddress = $this->sanitizeAddress($peerAddress);
 
-        return $data;
+        return array($data, $peerAddress);
     }
 
     protected function handleClose()


### PR DESCRIPTION
This came up during a chat in a private channel where there was some confusion about how `$peer` was populated. This PR fixes that be returning an `array()` and pulling those into two variables again using `list()`.