### PR TITLE
Prefix all global functions calls with \ to skip the look up and resolve process and go straight to the global function

### DIFF
--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -37,7 +37,7 @@ class Buffer extends EventEmitter
 
     public function onWritable()
     {
-        list($data, $remoteAddress) = array_shift($this->outgoing);
+        list($data, $remoteAddress) = \array_shift($this->outgoing);
 
         try {
             $this->handleWrite($data, $remoteAddress);
@@ -105,14 +105,14 @@ class Buffer extends EventEmitter
         if ($remoteAddress === null) {
             // do not use fwrite() as it obeys the stream buffer size and
             // packets are not to be split at 8kb
-            $ret = @stream_socket_sendto($this->socket, $data);
+            $ret = @\stream_socket_sendto($this->socket, $data);
         } else {
-            $ret = @stream_socket_sendto($this->socket, $data, 0, $remoteAddress);
+            $ret = @\stream_socket_sendto($this->socket, $data, 0, $remoteAddress);
         }
 
         if ($ret < 0 || $ret === false) {
-            $error = error_get_last();
-            throw new Exception('Unable to send packet: ' . trim($error['message']));
+            $error = \error_get_last();
+            throw new Exception('Unable to send packet: ' . \trim($error['message']));
         }
     }
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -28,7 +28,7 @@ class Factory
         if ($resolver === null) {
             // try to load nameservers from system config or default to Google's public DNS
             $config = Config::loadSystemConfigBlocking();
-            $server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
+            $server = $config->nameservers ? \reset($config->nameservers) : '8.8.8.8';
 
             $factory = new DnsFactory();
             $resolver = $factory->create($server, $loop);
@@ -43,7 +43,7 @@ class Factory
         $loop = $this->loop;
 
         return $this->resolveAddress($address)->then(function ($address) use ($loop) {
-            $socket = @stream_socket_client($address, $errno, $errstr);
+            $socket = @\stream_socket_client($address, $errno, $errstr);
             if (!$socket) {
                 throw new Exception('Unable to create client socket: ' . $errstr, $errno);
             }
@@ -57,7 +57,7 @@ class Factory
         $loop = $this->loop;
 
         return $this->resolveAddress($address)->then(function ($address) use ($loop) {
-            $socket = @stream_socket_server($address, $errno, $errstr, STREAM_SERVER_BIND);
+            $socket = @\stream_socket_server($address, $errno, $errstr, \STREAM_SERVER_BIND);
             if (!$socket) {
                 throw new Exception('Unable to create server socket: ' . $errstr, $errno);
             }
@@ -68,18 +68,18 @@ class Factory
 
     protected function resolveAddress($address)
     {
-        if (strpos($address, '://') === false) {
+        if (\strpos($address, '://') === false) {
             $address = 'udp://' . $address;
         }
 
         // parse_url() does not accept null ports (random port assignment) => manually remove
         $nullport = false;
-        if (substr($address, -2) === ':0') {
-            $address = substr($address, 0, -2);
+        if (\substr($address, -2) === ':0') {
+            $address = \substr($address, 0, -2);
             $nullport = true;
         }
 
-        $parts = parse_url($address);
+        $parts = \parse_url($address);
 
         if (!$parts || !isset($parts['host'])) {
             return Promise\resolve($address);
@@ -90,12 +90,12 @@ class Factory
         }
 
         // remove square brackets for IPv6 addresses
-        $host = trim($parts['host'], '[]');
+        $host = \trim($parts['host'], '[]');
 
         return $this->resolveHost($host)->then(function ($host) use ($parts) {
             $address = $parts['scheme'] . '://';
 
-            if (isset($parts['port']) && strpos($host, ':') !== false) {
+            if (isset($parts['port']) && \strpos($host, ':') !== false) {
                 // enclose IPv6 address in square brackets if a port will be appended
                 $host = '[' . $host . ']';
             }
@@ -113,7 +113,7 @@ class Factory
     protected function resolveHost($host)
     {
         // there's no need to resolve if the host is already given as an IP address
-        if (false !== filter_var($host, FILTER_VALIDATE_IP)) {
+        if (false !== \filter_var($host, \FILTER_VALIDATE_IP)) {
             return Promise\resolve($host);
         }
 

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -36,12 +36,12 @@ class Socket extends EventEmitter implements SocketInterface
 
     public function getLocalAddress()
     {
-        return $this->sanitizeAddress(@stream_socket_get_name($this->socket, false));
+        return $this->sanitizeAddress(@\stream_socket_get_name($this->socket, false));
     }
 
     public function getRemoteAddress()
     {
-        return $this->sanitizeAddress(@stream_socket_get_name($this->socket, true));
+        return $this->sanitizeAddress(@\stream_socket_get_name($this->socket, true));
     }
 
     public function send($data, $remoteAddress = null)
@@ -103,17 +103,17 @@ class Socket extends EventEmitter implements SocketInterface
         }
 
         // this is an IPv6 address which includes colons but no square brackets
-        $pos = strrpos($address, ':');
-        if ($pos !== false && strpos($address, ':') < $pos && substr($address, 0, 1) !== '[') {
-            $port = substr($address, $pos + 1);
-            $address = '[' . substr($address, 0, $pos) . ']:' . $port;
+        $pos = \strrpos($address, ':');
+        if ($pos !== false && \strpos($address, ':') < $pos && \substr($address, 0, 1) !== '[') {
+            $port = \substr($address, $pos + 1);
+            $address = '[' . \substr($address, 0, $pos) . ']:' . $port;
         }
         return $address;
     }
 
     protected function handleReceive(&$peerAddress)
     {
-        $data = stream_socket_recvfrom($this->socket, $this->bufferSize, 0, $peerAddress);
+        $data = \stream_socket_recvfrom($this->socket, $this->bufferSize, 0, $peerAddress);
 
         if ($data === false) {
             // receiving data failed => remote side rejected one of our packets
@@ -130,6 +130,6 @@ class Socket extends EventEmitter implements SocketInterface
 
     protected function handleClose()
     {
-        fclose($this->socket);
+        \fclose($this->socket);
     }
 }


### PR DESCRIPTION
Replacement PR for #27 