### PR TITLE
Accept DNS `ResolverInterface` and fix failing test suite

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.3",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
-        "react/dns": "^1.0 || ^0.4.13",
+        "react/dns": "^1.1",
         "react/promise": "~2.1|~1.2"
     },
     "require-dev": {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -3,9 +3,9 @@
 namespace React\Datagram;
 
 use React\Datagram\Socket;
-use React\Dns\Config\Config;
+use React\Dns\Config\Config as DnsConfig;
 use React\Dns\Resolver\Factory as DnsFactory;
-use React\Dns\Resolver\Resolver;
+use React\Dns\Resolver\ResolverInterface;
 use React\EventLoop\LoopInterface;
 use React\Promise;
 use React\Promise\CancellablePromiseInterface;
@@ -19,15 +19,15 @@ class Factory
     /**
      *
      * @param LoopInterface $loop
-     * @param Resolver|null $resolver Resolver instance to use. Will otherwise
+     * @param ?ResolverInterface $resolver Resolver instance to use. Will otherwise
      *     try to load the system default DNS config or fall back to using
      *     Google's public DNS 8.8.8.8
      */
-    public function __construct(LoopInterface $loop, Resolver $resolver = null)
+    public function __construct(LoopInterface $loop, ResolverInterface $resolver = null)
     {
         if ($resolver === null) {
             // try to load nameservers from system config or default to Google's public DNS
-            $config = Config::loadSystemConfigBlocking();
+            $config = DnsConfig::loadSystemConfigBlocking();
             $server = $config->nameservers ? \reset($config->nameservers) : '8.8.8.8';
 
             $factory = new DnsFactory();

--- a/tests/SocketTest.php
+++ b/tests/SocketTest.php
@@ -5,6 +5,7 @@ use Clue\React\Block;
 
 class SocketTest extends TestCase
 {
+    private $loop;
     private $factory;
 
     public function setUp()

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,9 +31,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
 
     protected function createResolverMock()
     {
-        return $this->getMockBuilder('React\Dns\Resolver\Resolver')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->getMockBuilder('React\Dns\Resolver\ResolverInterface')->getMock();
     }
 }
 


### PR DESCRIPTION
As of https://github.com/reactphp/dns/pull/134, all DNS classes are marked as `final`, including the `Resolver` class which is most commonly used in consuming packages. This changeset adjusts our `Factory` to accept the `ResolverInterface` interface as the common interface into this class and also adjust tests to use this interface for mocking. This is not a BC break because the interface is strictly compatible with the original `Resolver` behavior.

Builds on top of https://github.com/reactphp/socket/issues/208 and https://github.com/reactphp/socket/issues/207
Builds on top of https://github.com/reactphp/dns/pull/139 and https://github.com/reactphp/dns/pull/134