### PR TITLE
Run tests on PHPUnit 9 and update PHPUnit configuration schema for PHPUnit 9.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,5 @@
 /.travis.yml export-ignore
 /examples export-ignore
 /phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
 /tests export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,5 @@ install:
   - composer install
 
 script:
-  - vendor/bin/phpunit --coverage-text
+  - if [[ "$TRAVIS_PHP_VERSION" > "7.2" ]]; then vendor/bin/phpunit --coverage-text; fi
+  - if [[ "$TRAVIS_PHP_VERSION" < "7.3" ]]; then vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,26 @@
 language: php
 
-php:
-# - 5.3 # requires old distro, see below
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - hhvm # ignore errors, see below
-
 # lock distro so new future defaults will not break the build
 dist: trusty
 
-matrix:
+jobs:
   include:
     - php: 5.3
       dist: precise
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: 7.3
+    - php: 7.4
+    - php: hhvm-3.18
   allow_failures:
-    - php: hhvm
-
-sudo: false
+    - php: hhvm-3.18
 
 install:
-  - composer install --no-interaction
+  - composer install
 
 script:
   - vendor/bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,6 @@
     },
     "require-dev": {
         "clue/block-react": "~1.0",
-        "phpunit/phpunit": "^7.0 || ^6.0 || ^5.0 || ^4.8.35"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,23 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
->
+         colors="true"
+         cacheResult="false">
     <testsuites>
         <testsuite name="Datagram Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Datagram Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -13,7 +13,10 @@ class FactoryTest extends TestCase
     private $resolver;
     private $factory;
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpFactory()
     {
         $this->loop = \React\EventLoop\Factory::create();
         $this->resolver = $this->createResolverMock();
@@ -31,7 +34,7 @@ class FactoryTest extends TestCase
 
         $this->assertEquals('127.0.0.1:12345', $capturedClient->getRemoteAddress());
 
-        $this->assertContains('127.0.0.1:', $capturedClient->getLocalAddress());
+        $this->assertContainsString('127.0.0.1:', $capturedClient->getLocalAddress());
         $this->assertNotEquals('127.0.0.1:12345', $capturedClient->getLocalAddress());
 
         $capturedClient->close();
@@ -50,7 +53,7 @@ class FactoryTest extends TestCase
 
         $this->assertEquals('127.0.0.1:12345', $capturedClient->getRemoteAddress());
 
-        $this->assertContains('127.0.0.1:', $capturedClient->getLocalAddress());
+        $this->assertContainsString('127.0.0.1:', $capturedClient->getLocalAddress());
         $this->assertNotEquals('127.0.0.1:12345', $capturedClient->getLocalAddress());
 
         $capturedClient->close();
@@ -83,7 +86,7 @@ class FactoryTest extends TestCase
 
         $this->assertEquals('[::1]:12345', $capturedClient->getRemoteAddress());
 
-        $this->assertContains('[::1]:', $capturedClient->getLocalAddress());
+        $this->assertContainsString('[::1]:', $capturedClient->getLocalAddress());
         $this->assertNotEquals('[::1]:12345', $capturedClient->getLocalAddress());
 
         $capturedClient->close();
@@ -133,37 +136,26 @@ class FactoryTest extends TestCase
         $client->close();
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testCreateClientWithHostnameWillRejectIfResolverRejects()
     {
         $this->resolver->expects($this->once())->method('resolve')->with('example.com')->willReturn(Promise\reject(new \RuntimeException('test')));
 
+        $this->setExpectedException('RuntimeException');
         Block\await($this->factory->createClient('example.com:0'), $this->loop);
     }
 
-    /**
-     * @expectedException Exception
-     * @expectedExceptionMessage Unable to create client socket
-     */
     public function testCreateClientWithInvalidHostnameWillReject()
     {
+        $this->setExpectedException('Exception', 'Unable to create client socket');
         Block\await($this->factory->createClient('/////'), $this->loop);
     }
 
-    /**
-     * @expectedException Exception
-     * @expectedExceptionMessage Unable to create server socket
-     */
     public function testCreateServerWithInvalidHostnameWillReject()
     {
+        $this->setExpectedException('Exception', 'Unable to create server socket');
         Block\await($this->factory->createServer('/////'), $this->loop);
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testCancelCreateClientWithCancellableHostnameResolver()
     {
         $promise = new Promise\Promise(function () { }, $this->expectCallableOnce());
@@ -172,12 +164,10 @@ class FactoryTest extends TestCase
         $promise = $this->factory->createClient('example.com:0');
         $promise->cancel();
 
+        $this->setExpectedException('RuntimeException');
         Block\await($promise, $this->loop);
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testCancelCreateClientWithUncancellableHostnameResolver()
     {
         $promise = $this->getMockBuilder('React\Promise\PromiseInterface')->getMock();
@@ -186,6 +176,7 @@ class FactoryTest extends TestCase
         $promise = $this->factory->createClient('example.com:0');
         $promise->cancel();
 
+        $this->setExpectedException('RuntimeException');
         Block\await($promise, $this->loop);
     }
 }

--- a/tests/SocketTest.php
+++ b/tests/SocketTest.php
@@ -10,7 +10,10 @@ class SocketTest extends TestCase
     private $loop;
     private $factory;
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpFactory()
     {
         $this->loop = \React\EventLoop\Factory::create();
         $this->factory = new \React\Datagram\Factory($this->loop, $this->createResolverMock());

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -28,11 +28,45 @@ abstract class TestCase extends BaseTestCase
 
     protected function createCallableMock()
     {
-        return $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+        if (method_exists('PHPUnit\Framework\MockObject\MockBuilder', 'addMethods')) {
+            // PHPUnit 8.5+
+            return $this->getMockBuilder('stdClass')->addMethods(array('__invoke'))->getMock();
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 8.4
+            return $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+        }
     }
 
     protected function createResolverMock()
     {
         return $this->getMockBuilder('React\Dns\Resolver\ResolverInterface')->getMock();
+    }
+
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 5.2+
+            $this->expectException($exception);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 5.1
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+        }
+    }
+
+    public function assertContainsString($needle, $haystack)
+    {
+        if (method_exists($this, 'assertStringContainsString')) {
+            // PHPUnit 7.5+
+            $this->assertStringContainsString($needle, $haystack);
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 7.5
+            $this->assertContains($needle, $haystack);
+        }
     }
 }


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file, because the new format is unknown for them.
For further details concerning this pull request look into [graphp/graphviz #46](https://github.com/graphp/graphviz/pull/46).