### PR TITLE
Support falling back to multiple DNS servers from DNS config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "php": ">=5.3",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
-        "react/dns": "dev-master#ae37876 as 1.7.0",
+        "react/dns": "^1.7",
         "react/promise": "~2.1|~1.2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "php": ">=5.3",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
-        "react/dns": "^1.1",
+        "react/dns": "dev-master#ae37876 as 1.7.0",
         "react/promise": "~2.1|~1.2"
     },
     "require-dev": {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -28,10 +28,12 @@ class Factory
         if ($resolver === null) {
             // try to load nameservers from system config or default to Google's public DNS
             $config = DnsConfig::loadSystemConfigBlocking();
-            $server = $config->nameservers ? \reset($config->nameservers) : '8.8.8.8';
+            if (!$config->nameservers) {
+                $config->nameservers[] = '8.8.8.8'; // @codeCoverageIgnore
+            }
 
             $factory = new DnsFactory();
-            $resolver = $factory->create($server, $loop);
+            $resolver = $factory->create($config, $loop);
         }
 
         $this->loop = $loop;


### PR DESCRIPTION
This changeset adds support for falling back to multiple DNS servers from DNS config. In other words, if you have multiple DNS servers configured (rare) and connectivity to the primary DNS server is broken (even rarer), it will now fall back to your other DNS servers.

This is done by simply passing the complete list of DNS servers down to the DNS component that is responsible for setting up the DNS executor stack. Accordingly, this builds on top of https://github.com/reactphp/dns/pull/179 and https://github.com/reactphp/dns/pull/180. See also https://github.com/reactphp/socket/pull/257 for the same changes in the socket component.