### PR TITLE
Simplify usage by supporting new default loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ Once [installed](#install), you can use the following code to connect to an UDP 
 `localhost:1234` and send and receive UDP datagrams:  
 
 ```php
-$loop = React\EventLoop\Factory::create();
-$factory = new React\Datagram\Factory($loop);
+$factory = new React\Datagram\Factory();
 
 $factory->createClient('localhost:1234')->then(function (React\Datagram\Socket $client) {
     $client->send('first');
@@ -20,8 +19,6 @@ $factory->createClient('localhost:1234')->then(function (React\Datagram\Socket $
         echo 'received "' . $message . '" from ' . $serverAddress. PHP_EOL;
     });
 });
-
-$loop->run();
 ```
 
 See also the [examples](examples).

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "require": {
         "php": ">=5.3",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
-        "react/event-loop": "dev-master#78f7f43 as 1.2.0",
+        "react/event-loop": "^1.2",
         "react/dns": "^1.7",
         "react/promise": "~2.1|~1.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "require": {
         "php": ">=5.3",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
-        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
+        "react/event-loop": "dev-master#78f7f43 as 1.2.0",
         "react/dns": "^1.7",
         "react/promise": "~2.1|~1.2"
     },

--- a/examples/server.php
+++ b/examples/server.php
@@ -2,8 +2,7 @@
 
 require_once __DIR__.'/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-$factory = new React\Datagram\Factory($loop);
+$factory = new React\Datagram\Factory();
 
 $factory->createServer('localhost:1234')->then(function (React\Datagram\Socket $server) {
     $server->on('message', function($message, $address, $server) {
@@ -12,5 +11,3 @@ $factory->createServer('localhost:1234')->then(function (React\Datagram\Socket $
         echo 'client ' . $address . ': ' . $message . PHP_EOL;
     });
 });
-
-$loop->run();

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -6,6 +6,7 @@ use React\Datagram\Socket;
 use React\Dns\Config\Config as DnsConfig;
 use React\Dns\Resolver\Factory as DnsFactory;
 use React\Dns\Resolver\ResolverInterface;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Promise;
 use React\Promise\CancellablePromiseInterface;
@@ -18,13 +19,20 @@ class Factory
 
     /**
      *
-     * @param LoopInterface $loop
+     * This class takes an optional `LoopInterface|null $loop` parameter that can be used to
+     * pass the event loop instance to use for this object. You can use a `null` value
+     * here in order to use the [default loop](https://github.com/reactphp/event-loop#loop).
+     * This value SHOULD NOT be given unless you're sure you want to explicitly use a
+     * given event loop instance.
+     *
+     * @param ?LoopInterface $loop
      * @param ?ResolverInterface $resolver Resolver instance to use. Will otherwise
      *     try to load the system default DNS config or fall back to using
      *     Google's public DNS 8.8.8.8
      */
-    public function __construct(LoopInterface $loop, ResolverInterface $resolver = null)
+    public function __construct(LoopInterface $loop = null, ResolverInterface $resolver = null)
     {
+        $loop = $loop ?: Loop::get();
         if ($resolver === null) {
             // try to load nameservers from system config or default to Google's public DNS
             $config = DnsConfig::loadSystemConfigBlocking();

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -2,9 +2,9 @@
 
 namespace React\Tests\Datagram;
 
-use React\Datagram\Socket;
-use React\Datagram\Factory;
 use Clue\React\Block;
+use React\Datagram\Factory;
+use React\Datagram\Socket;
 use React\Promise;
 
 class FactoryTest extends TestCase
@@ -21,6 +21,17 @@ class FactoryTest extends TestCase
         $this->loop = \React\EventLoop\Factory::create();
         $this->resolver = $this->createResolverMock();
         $this->factory = new Factory($this->loop, $this->resolver);
+    }
+
+    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    {
+        $factory = new Factory();
+
+        $ref = new \ReflectionProperty($factory, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($factory);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
     }
 
     public function testCreateClient()


### PR DESCRIPTION
This changeset simplifies usage by supporting the new [default loop](https://github.com/reactphp/event-loop#loop).

```php
// old (still supported)
$factory = new React\Datagram\Factory($loop);

// new (using default loop)
$factory = new React\Datagram\Factory();
```

Builds on top of https://github.com/reactphp/event-loop/pull/226, https://github.com/reactphp/event-loop/pull/229 and https://github.com/reactphp/event-loop/pull/232
Refs https://github.com/reactphp/stream/pull/159