### PR TITLE
Avoid dependency on `ext-filter`

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -123,7 +123,7 @@ class Factory
     protected function resolveHost($host)
     {
         // there's no need to resolve if the host is already given as an IP address
-        if (false !== \filter_var($host, \FILTER_VALIDATE_IP)) {
+        if (@\inet_pton($host) !== false) {
             return Promise\resolve($host);
         }
 


### PR DESCRIPTION
This simple changeset avoids an unneeded (and undeclared!) dependency on `ext-filter`. The extension is enabled by default, but can explicitly be disabled with `--without-filter`.

The code in question is already covered by the test suite, so the test suite confirms this changeset does not affect behavior or our public API in any way. Accordingly, this is entirely transparent for all consumers of this package, plus now also supports consumers that happen use `--without-filter`.

The changes have been ported from https://github.com/reactphp/dns/pull/185
See https://www.php.net/manual/en/filter.installation.php
Originally reported in https://github.com/leproxy/leproxy/issues/80
Refs https://github.com/reactphp/socket/pull/17